### PR TITLE
Update SDK to 36, apply compatibility plan versions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,12 +15,12 @@ plugins {
 @Suppress("UnstableApiUsage")
 android {
     namespace = "dev.aurakai.auraframefx"
-    compileSdk = 34 // From plan
+    compileSdk = 36 // Addressing AAR metadata feedback
 
     defaultConfig {
         applicationId = "dev.aurakai.auraframefx"
-        minSdk = 31 // From plan
-        targetSdk = 34 // From plan
+        minSdk = 31 // As per compatibility plan (LSPosed)
+        targetSdk = 36 // Addressing AAR metadata feedback
         versionCode = 1
         versionName = "1.0"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,5 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m -Dfile.encoding=UTF-8
 #Mon Jun 23 18:53:16 MDT 2025
 android.enableJetifier=true
 android.useAndroidX=true
-android.suppressUnsupportedCompileSdk=34
+android.suppressUnsupportedCompileSdk=36
 ksp.useKSP2=true


### PR DESCRIPTION
- Set compileSdk and targetSdk to 36 to address AAR metadata issues.
- minSdk remains 31.
- Applied full compatibility plan versions for AGP (8.6.0), Kotlin (2.1.21), KSP (2.1.21-2.0.2), Hilt (2.56.2), NDK, CMake, Firebase BOM (33.15.0), Compose BOM (2025.06.00).
- Ensured ksp.useKSP2=true.
- Corrected settings.gradle.kts pluginManagement to use hardcoded versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the compileSdk and targetSdk versions to 36 for improved compatibility.
	- Explicitly noted the minSdk version for clarity.
	- Adjusted build configuration to suppress unsupported compile SDK warnings for version 36.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->