### PR TITLE
Fix: Migrate Hilt to KSP and remove Kapt plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     id("com.google.firebase.firebase-perf")
     id("org.jetbrains.kotlin.plugin.compose")
     id("com.google.devtools.ksp")
-    kotlin("kapt")
+    // kotlin("kapt") // Removed as Hilt and Room are on KSP
     id("org.openapi.generator") version "7.6.0"
 }
 
@@ -181,7 +181,7 @@ dependencies {
     
     // Hilt Dependency Injection
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler) // Changed from kapt to ksp
     implementation(libs.hilt.navigation.compose)
     
     // Room Database

--- a/app/local.properties
+++ b/app/local.properties
@@ -1,0 +1,1 @@
+sdk.dir=/opt/android-sdk

--- a/local.properties
+++ b/local.properties
@@ -1,0 +1,1 @@
+sdk.dir=/opt/android-sdk


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated build configuration from kapt to ksp for annotation processing.
  * Added local configuration files specifying the Android SDK path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->