### PR TITLE
Fix Hilt/KSP errors and update Compose Compiler config

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,11 +42,6 @@ android {
     buildFeatures {
         compose = true
     }
-    // Suppress incubating warning for composeOptions
-    @Suppress("UnstableApiUsage")
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
-    }
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"

--- a/app/src/main/java/dev/aurakai/auraframefx/services/AmbientMusicService.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/services/AmbientMusicService.kt
@@ -23,19 +23,19 @@ class AmbientMusicService @Inject constructor() : Service() {
     }
 
     // Example methods that might be relevant for a music service
-    fun pause() {
+    fun pause(): Unit {
         // TODO: Implement pause logic. Reported as unused. Implement or remove.
     }
 
-    fun resume() {
+    fun resume(): Unit {
         // TODO: Implement resume logic. Reported as unused. Implement or remove.
     }
 
-    fun setVolume(_volume: Float) {
+    fun setVolume(_volume: Float): Unit {
         // TODO: Reported as unused. Implement or remove.
     }
 
-    fun setShuffling(_isShuffling: Boolean) {
+    fun setShuffling(_isShuffling: Boolean): Unit {
         // TODO: Reported as unused. Implement or remove.
     }
 
@@ -49,11 +49,11 @@ class AmbientMusicService @Inject constructor() : Service() {
         return emptyList()
     }
 
-    fun skipToNextTrack() {
+    fun skipToNextTrack(): Unit {
         // TODO: Reported as unused. Implement or remove.
     }
 
-    fun skipToPreviousTrack() {
+    fun skipToPreviousTrack(): Unit {
         // TODO: Reported as unused. Implement or remove.
     }
 }

--- a/app/src/main/java/dev/aurakai/auraframefx/services/MyFirebaseMessagingService.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/services/MyFirebaseMessagingService.kt
@@ -7,8 +7,10 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class MyFirebaseMessagingService @Inject constructor() : FirebaseMessagingService() {
-    // TODO: If this service has dependencies to be injected, add them to the constructor.
+class MyFirebaseMessagingService : FirebaseMessagingService() {
+    // Dependencies should be injected using @Inject lateinit var if needed.
+    // Example:
+    // @Inject lateinit var myDependency: MyDependency
 
     private val tag = "MyFirebaseMsgService"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     id("com.google.firebase.crashlytics") apply false
     id("com.google.firebase.firebase-perf") apply false
     id("org.jetbrains.kotlin.plugin.serialization") apply false
-    id("org.jetbrains.kotlin.plugin.compose") apply false
+    alias(libs.plugins.kotlin.compose) apply false
     id("com.google.devtools.ksp") version "2.2.0-2.0.2" apply false
     id("org.openapi.generator") apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -94,7 +94,7 @@ openapi-generator = { id = "org.openapi.generator", version.ref = "openapiGenera
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlytics" }
 firebase-perf = { id = "com.google.firebase.firebase-perf", version.ref = "firebasePerf" }
-kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "composeCompiler" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 
 [libraries]
 # Core & Lifecycle

--- a/local.properties
+++ b/local.properties
@@ -1,0 +1,1 @@
+sdk.dir=/opt/android-sdk


### PR DESCRIPTION
- Switched to the new org.jetbrains.kotlin.plugin.compose Gradle plugin, aligning its version with the Kotlin version.
- Removed incorrect kotlinCompilerExtensionVersion from composeOptions.
- Fixed MyFirebaseMessagingService by removing @Inject constructor(), as Hilt does not support constructor injection for Android Services.
- Made Unit returns explicit in AmbientMusicService as an attempted fix for KSP 'unexpected jvm signature V' (may need revert post-CI fix).

Note: Build may still fail in CI due to 'SDK location not found' which requires environment configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin version references and usage for Kotlin Compose in build configuration files.
  * Added a local configuration file specifying the Android SDK path.
* **Refactor**
  * Updated method signatures in the music service to explicitly declare return types.
  * Modified dependency injection approach in the messaging service class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->